### PR TITLE
[nitpick] Stop docker container in CI

### DIFF
--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -26,17 +26,23 @@ jobs:
     - name: List Docker images
       run: docker images
 
-    - name: Run container and execute lake build
+    - name: Start container (in background)
+      run: docker run --name test-container -dti veil/latest
+
+    - name: Execute lake build
       id: run-container
       run: |
-        docker run --name test-container -dti veil/latest
+        set +e # stop this script from aborting if a command fails, s.t., the exit code can be captured
         docker exec test-container bash -c 'cd veil && /root/.elan/bin/lake build || exit $?'
         echo "exitcode=$?" >> $GITHUB_OUTPUT
+
+    - name: Stop container and cleanup docker
+      if: ${{ always() }}
+      run: |
         docker stop test-container
         docker rm test-container
 
-    - name: Report status
+    - name: Report exit code
       if: ${{ steps.run-container.outcome == 'failure' }}
       run: |
-        echo "The lake build process exited with a non-zero status."
-
+        echo "The lake build process exited with the non-zero exit code ${{ steps.run-container.outputs.exitcode }}."

--- a/.github/workflows/docker-build-and-test.yml
+++ b/.github/workflows/docker-build-and-test.yml
@@ -44,5 +44,4 @@ jobs:
 
     - name: Report exit code
       if: ${{ steps.run-container.outcome == 'failure' }}
-      run: |
-        echo "The lake build process exited with the non-zero exit code ${{ steps.run-container.outputs.exitcode }}."
+      run: echo "The lake build process exited with the non-zero exit code ${{ steps.run-container.outputs.exitcode }}."


### PR DESCRIPTION
While browsing your CI workflow file, I got puzzled about the way how you set the exit code, which made me realize that `docker stop test-container` is not invoked in case `lake build` exits unsuccessfully as running a script in a step aborts when encountering the first error.
Thus, this PR sets `set +e` to override this behavior. Since this has the potential of missing errors, I've split the affected step to apply this flag to the smallest number of bash commands.