### PR TITLE
fix: refuse to finalize spec when an assertion declaration failed to elaborate

### DIFF
--- a/Veil/Frontend/DSL/Module/Elaborators.lean
+++ b/Veil/Frontend/DSL/Module/Elaborators.lean
@@ -268,6 +268,8 @@ generating compiled model source. -/
 def Module.ensureSpecIsFinalized (mod : Module) (stx : Syntax) : CommandElabM Module := do
   if mod.isSpecFinalized then
     return mod
+  unless mod._failedAssertions.isEmpty do
+    throwError "cannot finalize the specification: the following assertion declaration(s) failed to elaborate: {mod._failedAssertions.toList}"
   let mod ← mod.ensureStateIsDefined
   throwIfNoInitializerDefined mod
   warnIfNoInvariantsDefined mod
@@ -590,9 +592,17 @@ def elabAssertion : CommandElab := fun stx => do
     | .stateConstraint => "state_constraint"
   withTraceNode (`veil.perf.elaborator.assertion ++ assertion.name) (fun _ => return s!"{kindStr} {assertion.name}") do
     -- Elaborate the assertion in the Lean environment
-    let mod' ← mod.defineAssertion assertion
+    try
+      let mod' ← mod.defineAssertion assertion
   --   dbg_trace s!"Elaborated assertion: {← liftTermElabM <|Lean.PrettyPrinter.formatTactic stx}"
-    localEnv.modifyModule (fun _ => mod')
+      localEnv.modifyModule (fun _ => mod')
+    catch ex =>
+      -- A failed assertion is not registered in the module. Record its name so
+      -- that `#gen_spec` refuses to finalize a specification that would
+      -- silently omit it (`#check_invariants` would then report all-green
+      -- without it).
+      localEnv.modifyModule (fun _ => { mod with _failedAssertions := mod._failedAssertions.push assertion.name })
+      throw ex
 
 @[command_elab Veil.genSpec]
 def elabGenSpec : CommandElab := fun stx => do

--- a/Veil/Frontend/DSL/Module/Representation.lean
+++ b/Veil/Frontend/DSL/Module/Representation.lean
@@ -374,6 +374,12 @@ structure Module where
   can still be added after this. -/
   protected _specFinalizedAt : Option Syntax := none
 
+  /-- Implementation detail. Names of assertion declarations that failed to
+  elaborate. Such assertions are not registered in `assertions`, so the
+  specification must not be finalized while any exist; otherwise the failed
+  assertion would be silently omitted from all subsequent checks. -/
+  protected _failedAssertions : Array Name := #[]
+
   /-- Assertions can be grouped into "sets", which are checked
   independently of each other. Sets are per-module. By default, all
   assertions are added to the same set. -/

--- a/VeilTest/Regression/DroppedAssertion.lean
+++ b/VeilTest/Regression/DroppedAssertion.lean
@@ -1,0 +1,34 @@
+import Veil
+
+-- An assertion whose body fails to elaborate is not registered in the module.
+-- Previously, `#gen_spec` would then finalize the specification without it and
+-- `#check_invariants` would report all-green, silently omitting the property.
+-- Now `#gen_spec` refuses to finalize while failed assertion declarations exist.
+
+veil module DroppedAssertion
+
+type node
+
+relation r : node → Bool
+
+#gen_state
+
+after_init {
+  r N := false
+}
+
+action flip (n : node) {
+  r n := true
+}
+
+/-- error: Unbound uncapitalized variable: N' -/
+#guard_msgs in
+invariant [uniqueness] r N ∧ r N' → N = N'
+
+/--
+error: cannot finalize the specification: the following assertion declaration(s) failed to elaborate: [uniqueness]
+-/
+#guard_msgs in
+#gen_spec
+
+end DroppedAssertion


### PR DESCRIPTION
If an assertion's body fails to elaborate (say, a typo like a primed variable `C'`, or a capitalized variable that happens to resolve to an existing global), the declaration errors but the assertion is simply not registered in the module. `#gen_spec` then finalizes the specification without it, and `#check_invariants` reports all green. The property the user wrote is silently gone; if the model has a bug that property would catch, the report still looks like a clean pass. On a small mutex model with `safety [mutual_exclusion] holds C ∧ holds C' → C = C'`:

```
error: Unbound uncapitalized variable: C'
info: Initialization must establish the invariant:
  doesNotThrow ... ✅
  lock_consistency ... ✅
The following set of actions must preserve the invariant and successfully terminate:
  acquire
    doesNotThrow ... ✅
    lock_consistency ... ✅
  ...
```

`mutual_exclusion` appears nowhere in the roster, and in a 40+ minute build log the lone error line is easy to lose while the wall of green reads as verified, which nearly bit me.

This PR makes the failure impossible to miss. `elabAssertion` records the names of assertion declarations that fail to elaborate, and `Module.ensureSpecIsFinalized` refuses to finalize the specification while any exist. Since `#check_invariants`, `#check_action`, trace commands, and `#model_check` all require a finalized spec, nothing downstream can run against a specification that silently lost an assertion. Same model, after:

```
error: Unbound uncapitalized variable: C'
error: cannot finalize the specification: the following assertion declaration(s) failed to elaborate: [mutual_exclusion]
error: The specification of module Mutex has not been finalized. Please call #gen_spec first!
```

The change is pretty small: a `_failedAssertions : Array Name` field on `Module`, a try/catch in `elabAssertion` that records the name and rethrows, and the finalization gate. `VeilTest/Regression/DroppedAssertion.lean` guards both the declaration error and the new `#gen_spec` error. Full `lake build` (Veil + VeilTest) passes.

One design choice though: a recorded failure is _not_ scrubbed if a later declaration with the same name succeeds; the broken declaration still has to be fixed or removed. Scrubbing would reopen the silent-omission path, since a later unrelated assertion reusing the name could mask the failed one.

Happy to adjust if needed, for instance a warning instead of a hard error, or reporting the dropped names in the `#check_invariants` output as well.
