### PR TITLE
Fix Veil 2.0 preview checkout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Then, clone Veil:
 
 ```bash
 git clone https://github.com/verse-lab/veil.git
-cd veil && git checkout veil-2.0
+cd veil && git checkout veil-2.0-preview
 ```
 
 And, finally, build it:


### PR DESCRIPTION
## What changed
Correct the checkout command in the Veil 2.0 pre-release README.

## Why
`veil-2.0` is not a current remote branch; `veil-2.0-preview` is. Following the documented command fails before the build starts.

## Validation
- Confirmed `veil-2.0-preview` exists on the upstream remote
- Confirmed `veil-2.0` does not exist on the upstream remote
- Ran `git diff --check`