### PR TITLE
Remove redundant `get`s inserted after monadic operations

### DIFF
--- a/Veil/Frontend/DSL/Action/DoElab/Assign.lean
+++ b/Veil/Frontend/DSL/Action/DoElab/Assign.lean
@@ -434,10 +434,9 @@ private def elabPureAssignment (ctx : Context) (target : Target)
 def elabStateReassign : DoElab := fun stx dec => do
   let ctx ← requireVeilDoBlock
   let some (target, type?, rhs) ← catchUnsupported? (parseReassign stx)
-    | -- Pattern-shaped targets are Lean's business, but their right-hand
-      -- sides still read state: keep this statement's fresh opening.
-      openStateAround ctx.mod <| Lean.Elab.Do.elabDoReassign stx dec
-  openStateAround ctx.mod <| elabPureAssignment ctx target type? rhs stx dec
+    | -- Pattern-shaped targets are Lean's business, but they may write state.
+      Lean.Elab.Do.elabDoReassign stx (openStateAfter ctx.mod dec)
+  elabPureAssignment ctx target type? rhs stx (openStateAfter ctx.mod dec)
 
 private def withArrowResult (target : Target) (type? : Option Term)
     (rhs : DoElem) (ref : Syntax)
@@ -453,10 +452,10 @@ private def withArrowResult (target : Target) (type? : Option Term)
 def elabStateReassignArrow : DoElab := fun stx dec => do
   let ctx ← requireVeilDoBlock
   let some { target, type?, rhs, hasFallback } ← catchUnsupported? (parseReassignArrow stx)
-    | -- Pattern-shaped targets are Lean's business, inside a fresh opening
-      -- (see `elabStateReassign`).
-      openStateAround ctx.mod <| Lean.Elab.Do.elabDoReassignArrow stx dec
-  openStateAround ctx.mod do
+    | -- Pattern-shaped targets are Lean's business (see `elabStateReassign`).
+      Lean.Elab.Do.elabDoReassignArrow stx (openStateAfter ctx.mod dec)
+  let dec := openStateAfter ctx.mod dec
+  do
     match ← resolveAssignmentTarget ctx target with
     | .local =>
       if hasFallback then
@@ -546,7 +545,8 @@ def elabHavoc : DoElab := fun stx dec => do
   let ctx ← requireVeilDoBlock
   let `(doElem| $lhs:term := *) := stx | throwUnsupportedSyntax
   let target ← parseTarget lhs
-  openStateAround ctx.mod do
+  let dec := openStateAfter ctx.mod dec
+  do
     let caps ← implicitCapitals ctx target.args
     checkRepeatedCapitals target caps
     match ← resolveAssignmentTarget ctx target with

--- a/Veil/Frontend/DSL/Action/DoElab/Context.lean
+++ b/Veil/Frontend/DSL/Action/DoElab/Context.lean
@@ -237,6 +237,34 @@ private def bindInternalResult (ref : Syntax) (hint operation : Name)
   let rhs ← `(doElem| veil_do_internal_expr% $(mkIdent operation):term)
   elabDoIdDecl (mkIdentFrom ref name) none rhs (k name)
 
+/-- Reopen all unshadowed mutable fields from a fresh monadic `get`, then run
+the statement elaborator directly. -/
+def openStateAround (mod : Module) (k : DoElabM Expr) : DoElabM Expr := do
+  let ref ← getRef
+  let shadowed ← userLocalNames
+  bindInternalResult ref `state ``get fun stateName =>
+    bindStateFields shadowed stateName mod.mutableComponents k
+
+/-- Open the state for everything *after* the current statement, by wrapping the
+continuation rather than the statement.
+
+A handler uses this exactly when the monadic operation it emits may write the
+state; handlers that emit only state-preserving operations (`require`, `assert`,
+a pure `let`, …) pass `dec` through untouched and the next statement reuses the
+opening already in scope. The classification is local to each handler and needs
+no cross-statement bookkeeping: Lean lifts every `(← e)` out into its own
+`doElem` *before* dispatching to a handler (`Lean.Elab.Do.elabDoElem`), so a
+handler that claims to be state-preserving cannot be hiding an effect. -/
+def openStateAfter (mod : Module) (dec : DoElemCont) : DoElemCont :=
+  { dec with k := do
+      /- When nothing after this statement is reachable (both branches of an
+      `if` returned, say) there is no one to read the state, and emitting the
+      opening would make Lean report the generated element as dead code. -/
+      if (← read).deadCode matches .alive then
+        openStateAround mod dec.k
+      else
+        dec.k }
+
 syntax (name := theoryOpen) "veil_do_open_theory%" : doElem
 
 @[doElem_control_info theoryOpen]
@@ -251,15 +279,9 @@ def elabTheoryOpen : DoElab := fun stx dec => do
   let shadowed ← userLocalNames
   bindInternalResult stx `theory ``read fun theoryName =>
     bindTheoryFields shadowed theoryName ctx.mod.immutableComponents
-      dec.continueWithUnit
-
-/-- Reopen all unshadowed mutable fields from a fresh monadic `get`, then run
-the statement elaborator directly. -/
-def openStateAround (mod : Module) (k : DoElabM Expr) : DoElabM Expr := do
-  let ref ← getRef
-  let shadowed ← userLocalNames
-  bindInternalResult ref `state ``get fun stateName =>
-    bindStateFields shadowed stateName mod.mutableComponents k
+      /- The first statement of the body needs field views in scope; every later
+      opening is emitted by the preceding state-writing statement. -/
+      (openStateAround ctx.mod dec.continueWithUnit)
 
 /-- Inline generated field views, and ordinary local lets derived from them,
 when an expression's outer shape must be visible to a later consumer. -/

--- a/Veil/Frontend/DSL/Action/DoElab/Statements.lean
+++ b/Veil/Frontend/DSL/Action/DoElab/Statements.lean
@@ -21,11 +21,13 @@ def assertionControlInfo : ControlInfoHandler := fun _ =>
 private def elabAssertionStatement (operation : Name) (stx : DoElem)
     (proposition : Term) (dec : DoElemCont) : DoElabM Expr := do
   let ctx ← requireVeilDoBlock
-  openStateAround ctx.mod do
-    let assertionId ← mkNewAssertion ctx.proc stx
-    let term ← `($(mkIdent operation) $proposition $(Syntax.mkNatLit assertionId.toNat))
-    let elem ← `(doElem| $term:term)
-    Lean.Elab.Do.elabDoExpr elem (← dec.ensureUnitAt stx)
+  /- `VeilM.require`/`VeilM.assert` are `assume`/`assert`: they never write the
+  state, so the continuation is passed through and the next statement reuses the
+  opening already in scope. -/
+  let assertionId ← mkNewAssertion ctx.proc stx
+  let term ← `($(mkIdent operation) $proposition $(Syntax.mkNatLit assertionId.toNat))
+  let elem ← `(doElem| $term:term)
+  Lean.Elab.Do.elabDoExpr elem (← dec.ensureUnitAt stx)
 
 @[doElem_elab requireDo, doElem_elab assertDo]
 def elabAssertion : DoElab := fun stx dec => do
@@ -72,12 +74,20 @@ private def boundIdents (stx : DoElem) : DoElabM (Array Ident) := do
 private def warnShadowingBinders (ctx : Context) (stx : DoElem) : DoElabM Unit := do
   (← boundIdents stx).forM (warnComponentShadow ctx)
 
+/-- Delegate to Lean's builtin handler.
+
+`preservesState := true` marks a statement whose monadic operation cannot write
+the state; it passes the continuation through unchanged and the following
+statements reuse the opening already in scope. Everything else re-opens the
+state *after* itself via `openStateAfter`. -/
 private def delegate (builtin : DoElab)
     (before : Context → DoElem → DoElabM Unit := fun _ _ => pure ())
-    (after : Context → Expr → DoElabM Expr := fun _ e => pure e) : DoElab := fun stx dec => do
+    (after : Context → Expr → DoElabM Expr := fun _ e => pure e)
+    (preservesState : Bool := false) : DoElab := fun stx dec => do
   let ctx ← requireVeilDoBlock
   before ctx stx
-  openStateAround ctx.mod do after ctx (← builtin stx dec)
+  let dec := if preservesState then dec else openStateAfter ctx.mod dec
+  after ctx (← builtin stx dec)
 
 private def doExprHeadName? (stx : DoElem) : Option Name :=
   match stx with
@@ -104,10 +114,12 @@ def elabVeilNested : DoElab := delegate Lean.Elab.Do.elabDoNested
 @[doElem_elab Lean.Parser.Term.doLet]
 def elabVeilLet : DoElab :=
   delegate Lean.Elab.Do.elabDoLet (before := warnShadowingBinders)
+    (preservesState := true)
 
 @[doElem_elab Lean.Parser.Term.doHave]
 def elabVeilHave : DoElab :=
   delegate Lean.Elab.Do.elabDoHave (before := warnShadowingBinders)
+    (preservesState := true)
 
 @[doElem_elab Lean.Parser.Term.doLetArrow]
 def elabVeilLetArrow : DoElab :=
@@ -142,10 +154,10 @@ def elabVeilMatch : DoElab := delegate Lean.Elab.Do.elabDoMatch
     (after := fun ctx result => zetaFieldDerivedLets ctx.mod result)
 
 @[doElem_elab Lean.Parser.Term.doReturn]
-def elabVeilReturn : DoElab := delegate Lean.Elab.Do.elabDoReturn
+def elabVeilReturn : DoElab := delegate Lean.Elab.Do.elabDoReturn (preservesState := true)
 
 @[doElem_elab Lean.Parser.Term.doDbgTrace]
-def elabVeilDbgTrace : DoElab := delegate Lean.Elab.Do.elabDoDbgTrace
+def elabVeilDbgTrace : DoElab := delegate Lean.Elab.Do.elabDoDbgTrace (preservesState := true)
 
 private def unsupportedMessage : SyntaxNodeKind → MessageData
   | ``Lean.Parser.Term.doLetRec => "recursive local declarations are not supported in Veil actions"

--- a/Veil/Frontend/DSL/Action/Extract.lean
+++ b/Veil/Frontend/DSL/Action/Extract.lean
@@ -42,6 +42,44 @@ dsimproc_decl simpFieldRepresentationSetSingle (Veil.FieldRepresentation.setSing
   let res ← Veil.Simp.dsimp (#[`dsimpFieldRepresentationSet] ++ getLocalDSimpTargets a b) {} e'
   return .done res.expr
 
+/-- Names under which the extracted code spells "read the state". Used only as
+a cheap filter before the definitional check below. -/
+private def isStateRead (e : Expr) : Bool :=
+  let e :=
+    let (n, args) := e.consumeMData.getAppFnArgs
+    if n == ``MonadFlatMapGo.go then (args.back?.getD e) else e
+  match e.consumeMData.getAppFn.constName? with
+  | some n => n == ``MonadStateOf.get || n == ``MonadState.get || n == ``getThe
+  | none => false
+
+/-- Drop a state read whose result is discarded by a `pure` continuation.
+
+The frontend opens the state after every statement that may write it; when the
+last such statement is the last statement of the body, the opening it emits has
+nothing left to read. In `VeilMultiExecM` the `get` is state threading and the
+`pure` continuation is a literal singleton, so `get >>= fun _ => pure e` reduces
+to `pure e`, but rather than rely on that, the rewrite is only performed after
+`isDefEq` confirms it. The name test above is a fast filter, not the
+justification: if the two sides are not definitionally equal nothing happens,
+whatever monad or `MonadStateOf` instance the `get` came from. -/
+dsimproc_decl dropDiscardedStateRead (Bind.bind _ _) := fun e => do
+  /- NOTE: every non-firing path must `continue`, not `done`: this fires on
+  `Bind.bind`, which is everywhere, and `done` would stop dsimp from
+  normalising the rest of the extracted term. -/
+  let_expr Bind.bind _m _inst _a _b act k := e | return .continue
+
+  let .lam _ _ body _ := k | return .continue
+  unless isStateRead act do return .continue
+  if body.hasLooseBVar 0 then return .continue
+  let rhs := body.lowerLooseBVars 1 1
+  unless rhs.consumeMData.getAppFn.isConstOf ``Pure.pure do return .continue
+  /- `dsimp` matches at reducible transparency, but the monad stack only unfolds
+  at default; without this the check always fails. -/
+  if ← withDefault (isDefEq e rhs) then
+    trace[veil.debug] m!"[{decl_name%}]: dropped discarded state read"
+    return .visit rhs
+  return .continue
+
 end Preprocessing
 
 /-
@@ -355,6 +393,11 @@ attribute [multiextracted] ConstrainedExtractResult.pure
   ConstrainedExtractResult.pickSuchThat_VeilM
   ConstrainedExtractResult.assume_VeilM
   ConstrainedExtractResult.require_VeilM
+
+/- Registered as a *post* procedure (no `↓`): it must see the fully normalised
+`Bind.bind (go get) (fun _ => pure e)` shape, which only exists after the
+`ConstrainedExtractResult` layer above has been simplified away. -/
+attribute [multiExtractSimp] Preprocessing.dropDiscardedStateRead
 
 open MultiExtractor in
 attribute [multiExtractSimp ↓] ConstrainedExtractResult.pure


### PR DESCRIPTION
## Problem

The frontend makes the state available to a statement by binding a snapshot with a monadic `get` and projecting the fields out of it. It cannot tell syntactically whether the *previous* statement wrote, so it does this before **every** statement: a body with five `require`s and one assignment elaborated to six `get`s where the pre-port frontend produced one.

This slows down the execution of actions. For example, model checker now can take 50% more time on certain specs than before.

## Current Plan

**1. Open the state after each statement that may write it.** 

`delegate` wraps the *continuation* instead of the statement:

```lean
-- before
openStateAround mod (builtin stx dec)
-- after
builtin stx (openStateAfter mod dec)
```

Each handler answers a local question — "can the operation I emit write the state?" — with no cross-statement bookkeeping. `require`, `assert`, a pure `let`/`have`, `return` and `dbg_trace` pass the continuation through, so following statements reuse the opening in scope.

This is sound because Lean lifts every `(← e)` into its own `doElem` *before* dispatching to a handler (`elabDoElem` runs `expandNestedActions` and re-enters through `elabDoElems1`, only then consulting `doElemElabAttribute`). A handler claiming to preserve state cannot be hiding an effect: `require (← bump n)` becomes `let __do_lift ← bump n; require __do_lift`, and the lifted arrow-bind re-opens the state itself. `if` needs nothing special — its continuation is a join point, so the opening is built once and both branches jump to it.

Two details: the body's preamble now performs the first opening, and nothing is emitted into a dead continuation (which would make Lean report the *generated* statement as dead code).

**2. Drop the trailing read during extraction.** 

The opening emitted after a body's last write has nothing left to read. `dropDiscardedStateRead`, a `dsimproc_decl`, rewrites `get >>= fun _ => pure e` to `pure e` — definitional on `VeilMultiExecM`, and only applied after `isDefEq` confirms it, so nothing is assumed about which `MonadStateOf` instance the `get` came from. Three non-obvious requirements: it must be registered **post** (`attribute [multiExtractSimp]`; by-name simprocs are added as *pre*, where the `ConstrainedExtractResult` layer is still in the way); non-firing paths must return `.continue`, since `.done` on a `Bind.bind` key stops `dsimp` descending and freezes extraction; and the `isDefEq` check needs `withDefault`, as `dsimp` matches at reducible transparency.