### PR TITLE
docs: update install docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.lake
+.agents
+.claude
+.codex
+widget/node_modules
+widget/dist
+veil.zip
+.veil.tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
 FROM ubuntu:24.04
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 WORKDIR /root
 
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -y && \
-    apt-get install -y software-properties-common build-essential curl unzip git && \
-    apt-get clean
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      ca-certificates curl git unzip clang lld libc++-dev libc++abi-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN bash -c 'curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:stable'
+RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.7/install.sh | bash
+RUN . "$HOME/.nvm/nvm.sh" && nvm install 24
+RUN curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | \
+    sh -s -- -y --default-toolchain none
+ENV PATH="/root/.elan/bin:${PATH}"
 
-RUN mkdir veil
-COPY veil.zip /root
-RUN unzip veil.zip  && mv .veil.tmp/* veil && rm veil.zip
-
-
+WORKDIR /root/veil
+COPY . .
+RUN . "$HOME/.nvm/nvm.sh" && lake exe cache get && lake build
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -52,16 +52,20 @@ An explanation of the constructs of the Veil DSL can be found at
 ## Build
 
 Veil requires [Lean 4](https://github.com/leanprover/lean4) and
-[NodeJS](https://nodejs.org/en/download/). To install those on Linux or MacOS:
+[NodeJS](https://nodejs.org/en/download/), and Lean CVC5 requires
+[Clang](https://releases.llvm.org/download.html). To install those on Linux or
+MacOS:
 
 ```bash
-# Install Lean
-curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y --default-toolchain leanprover/lean4:stable
-
-# Install NodeJS
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
-\. "$HOME/.nvm/nvm.sh"
-nvm install 24
+set -o pipefail &&
+sudo apt-get update &&
+sudo apt-get install -y --no-install-recommends \
+  ca-certificates curl git unzip clang lld libc++-dev libc++abi-dev &&
+(curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.7/install.sh | bash) &&
+. "$HOME/.nvm/nvm.sh" &&
+nvm install 24 &&
+(curl -fsSL https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh | sh -s -- -y --default-toolchain none) &&
+. "$HOME/.elan/env"
 ```
 
 Then, clone Veil:


### PR DESCRIPTION
Clang is not strictly needed, but sometimes the Lean CVC5 release fails to download, and in those cases Clang is needed to complete the build.